### PR TITLE
Create SecurityConfig.java

### DIFF
--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
@@ -1,0 +1,22 @@
+package csc450.BackEnd;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable) // disable CSRF for development
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/register", "/api/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}


### PR DESCRIPTION
* Purpose: The class overrides Spring Security’s default behavior.
* By default, Spring Security:
* - Locks down everything
* - Requires full authentication for every endpoint
* - Enables CSRF protection (which can break APIs without setup)
* - So without a SecurityConfig, routes like /api/login or /api/register would return 401/403 or reject requests due to CSRF.
* */