### PR TITLE
Update securityconfig

### DIFF
--- a/FinancialBloom/Backend/spring-backend/BackEnd/.gitignore
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/.gitignore
@@ -26,6 +26,8 @@ target/
 /nbdist/
 /.nb-gradle/
 build/
+/out/
+
 !**/src/main/**/build/
 !**/src/test/**/build/
 

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/CreateAccountController.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/CreateAccountController.java
@@ -4,17 +4,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
+
+
 @RestController
 @RequestMapping("/api")
 public class CreateAccountController {
 
+    private final CreateAccountService service;
+
     @Autowired
-    private CreateAccountService createAccountService;
+    public CreateAccountController(CreateAccountService service) {
+        this.service = service;
+    }
 
     @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody CreateAccountRequest request) {
-        String result = createAccountService.registerUser(request);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<?> register(@RequestBody CreateAccountRequest request) {
+        String resultMessage = service.registerUser(request);
+        return ResponseEntity.ok(Collections.singletonMap("message", resultMessage));
     }
 }
+
 

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/LoginController.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/LoginController.java
@@ -4,23 +4,57 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+
 @RestController
-@RequestMapping("/api/login")
+@RequestMapping("/api")
 public class LoginController {
 
     @Autowired
     private UserRepository userRepository;
 
-    @PostMapping
-    public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest) {
-        String email = loginRequest.getEmail();
-        String password = loginRequest.getPassword();
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+        String username = loginRequest.getUsername();
+        String rawPassword = loginRequest.getPassword();
 
-        User user = userRepository.findByEmailAndPassword(email, password);
-        if (user != null) {
-            return ResponseEntity.ok("Login successful! Welcome, " + user.getFName() + " " + user.getLName());
-        } else {
-            return ResponseEntity.status(401).body("Invalid credentials. Please try again.");
+        System.out.println("LoginRequest payload: username=" + loginRequest.getUsername() + ", password=" + loginRequest.getPassword());
+        ;
+        System.out.println("Raw input password: " + rawPassword);
+        User user = userRepository.findByUsername(username);
+
+        if (user == null) {
+            System.out.println("User not found.");
+            return ResponseEntity.status(401).build();
+        }
+
+        boolean passwordMatch = verifyPassword(rawPassword, user.getPassword());
+        System.out.println("Password match: " + passwordMatch);
+
+        if (!passwordMatch) {
+            return ResponseEntity.status(401).build();
+        }
+
+        return ResponseEntity.ok(Collections.singletonMap("success", true));
+    }
+
+    // Make sure this matches how you hashed it in CreateAccountService
+    private boolean verifyPassword(String inputPassword, String storedHash) {
+        try {
+            String[] parts = storedHash.split(":");
+            byte[] salt = Base64.getDecoder().decode(parts[0]);
+            byte[] expectedHash = Base64.getDecoder().decode(parts[1]);
+
+            PBEKeySpec spec = new PBEKeySpec(inputPassword.toCharArray(), salt, 65536, 128);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            byte[] actualHash = factory.generateSecret(spec).getEncoded();
+
+            return java.util.Arrays.equals(expectedHash, actualHash);
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/LoginRequest.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/LoginRequest.java
@@ -36,13 +36,13 @@ Created on 3.17.2025 by Temo Galinda: Initial login implementation.
 package csc450.BackEnd;
 
 public class LoginRequest {
-    private String email;
+    private String username;
     private String password;
 
     public LoginRequest() {}
 
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
 
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
@@ -1,3 +1,13 @@
+/*
+Name: Daniela Luna
+Purpose: The class overrides Spring Security’s default behavior.
+By default, Spring Security:
+- Locks down everything
+- Requires full authentication for every endpoint
+- Enables CSRF protection (which can break APIs without setup)
+So without a SecurityConfig, routes like /api/login or /api/register would return 401/403 or reject requests due to CSRF.
+*/
+
 package csc450.BackEnd;
 
 import org.springframework.context.annotation.Bean;
@@ -5,7 +15,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+
 
 @Configuration
 @EnableWebSecurity
@@ -20,5 +33,10 @@ public class SecurityConfig {
                 )
                 .build();
     }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
 }
 

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/SecurityConfig.java
@@ -12,6 +12,7 @@ package csc450.BackEnd;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,18 +26,23 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http
-                .csrf(AbstractHttpConfigurer::disable)
+        http
+                .csrf(AbstractHttpConfigurer::disable) // For now, disable CSRF for frontend dev
+                .cors(Customizer.withDefaults())        // Enable CORS
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/register", "/api/login").permitAll()
                         .anyRequest().authenticated()
                 )
-                .build();
+                .httpBasic(AbstractHttpConfigurer::disable) // 🔥 disables HTTP Basic Auth
+                .formLogin(AbstractHttpConfigurer::disable); // 🔥 disables form-based login
+
+        return http.build();
     }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 }
+
 

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/User.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/User.java
@@ -90,6 +90,10 @@ public class User {
     public void setNewUsername(String username) { this.username = username; }
     public void setNewEmail(String newEmail) { this.email = newEmail; }
     public void setNewPassword(String newPass) { this.password = newPass; }
+    public String getPassword() {
+        return this.password;
+    }
+
 
     // NOTE: login logic is normally handled by a service layer or Spring Security
     public boolean login(String emailAttempt, String passAttempt) {

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/UserController.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/UserController.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
+
 import java.util.List;
 
 @RestController

--- a/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/UserRepository.java
+++ b/FinancialBloom/Backend/spring-backend/BackEnd/src/main/java/csc450/BackEnd/UserRepository.java
@@ -8,5 +8,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     // Optional custom query methods:
     User findByEmail(String email);
-    User findByEmailAndPassword(String email, String password);
+    User findByUsername(String username);
+
 }


### PR DESCRIPTION
- Updated Login.html to send username in fetch POST to /api/login.
- Modified LoginRequest class to use username instead of email.
- Updated LoginController to call findByUsername() and verify hashed password.
- Added getPassword() method in User class for login comparison.
- Fixed UserRepository to include findByUsername().
- Confirmed SecurityConfig allows /api/login and /api/register.
- Cleaned up CreateAccountService to match hashing logic.